### PR TITLE
Fix for pending icon not showing

### DIFF
--- a/src/app/components/list/list.controller.js
+++ b/src/app/components/list/list.controller.js
@@ -200,12 +200,17 @@
             checkInId = list._id;
           }
         });
-        //update currentUser
-        user.pending = false;
-
+         
         if (checkInId) {
           UserCheckInService.update({userId: user._id, listType: $scope.list.type + 's', checkInId: checkInId}, {pending: false}, function () {
             alertService.add('success', gettextCatalog.getString('The user was successfully approved.'));
+
+            //update user
+            angular.forEach(user[$scope.list.type + 's'], function(userList) {
+                if (userList.list._id === $scope.list._id) {
+                  userList.pending = false;
+                }
+            });
           });
         }
       });

--- a/src/app/components/user/userOptions.html
+++ b/src/app/components/user/userOptions.html
@@ -3,7 +3,7 @@
     <icon name="dots" text="User options"></icon>
   </button>
   <ul class="dropdown-menu dropdown-menu--small" uib-dropdown-menu>
-    <li ng-if="list && user.pending && (currentUser.is_admin || isManager || isOwner)">
+    <li ng-if="list && isPending(user) && (currentUser.is_admin || isManager || isOwner)">
       <button type="button" class="btn-link" ng-click="approveUser(user)" translate>Approve</button>
     </li>
     <li ng-if="currentUser.is_admin || currentUser.isManager"><a href="/users/{{user._id}}/edit" translate>Edit</a></li>

--- a/src/app/components/user/users.controller.js
+++ b/src/app/components/user/users.controller.js
@@ -27,26 +27,23 @@
       $scope.request.offset = ($scope.currentPage - 1) * $scope.itemsPerPage;
       var params = angular.extend($scope.request, $scope.userFilters);
       UserDataService.getUsers(params).then(function (users) {
-        $scope.users = checkPending(users);
+        $scope.users = users;
         $scope.totalItems = users.headers["x-total-count"];
       });
     }
 
-    function checkPending (users) {
-      if (!$scope.list) {
-        return users;
-      }
 
+    $scope.isPending = function (user) {
       var listType = $scope.list.type + 's';
+      var pending = false;
 
-      angular.forEach(users, function (user) {
-        angular.forEach(user[listType], function (list) {
-          if ( ($scope.list._id === list.list._id) && list.pending) {
-            user.pending = true;
-          }
-        });
+      angular.forEach(user[listType], function (list) {
+        if ( ($scope.list._id === list.list._id) && list.pending) {
+          pending = true;
+          return;
+        }
       });
-      return users;
+      return pending;
     }
 
     $scope.$on('users-export-csv', function () {

--- a/src/app/components/user/users.html
+++ b/src/app/components/user/users.html
@@ -56,7 +56,7 @@
       <td>{{user.location.country.name}}</td>
 
       <td class="table-actions">
-        <icon name="caution" text="Pending" title="Pending" ng-if="user.pending"></icon>
+        <icon name="caution" text="Pending" title="Pending" ng-if="list && isPending(user)"></icon>
         <ng-include src="'app/components/user/userOptions.html'"></ng-include>
       </td>
     </tr>


### PR DESCRIPTION
@guillaumev This is to fix the issue I had where the pending icon for a user in a list was only showing briefly then disappearing. I think I've narrowed this down to being related to cached-resource 
- it resolves the promise from requesting the users instantly with the cached version
- this is then decorated in the controller to mark users as pending, so the icon shows
- when the api request resolves the users object is updated with the response, which isn't decorated, so the icon disappears.

My fix is to change the pending check to be done for each user in the ng-repeat. This is less efficient than decorating the users object as functions in ng-repeats are run on each digest.

If you have any other ideas on how to fix this they'd be welcome.