### PR TITLE
[OPS-3212] Test fail 😩

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,15 @@ cache:
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - npm install
-  - npm install -g grunt-cli
-  - npm install -g bower
-  - npm install -g protractor
-  - bower install
-  - webdriver-manager update
+  - npm install || exit 1
+  - npm install -g grunt-cli || exit 1
+  - npm install -g bower || exit 1
+  - npm install -g protractor || exit 1
+  - bower install || exit 1
+  - webdriver-manager update --gecko false || exit 1
   - npm start &
   - sleep 3
-  - grunt test-config --target="test"
+  - grunt test-config --target="test" || exit 1
   - sleep 3
 script:
   - npm run ci

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Humanitarian ID Web App version 2
 
+[![Build Status](https://travis-ci.org/UN-OCHA/hid_app2.svg?branch=master)](https://travis-ci.org/UN-OCHA/hid_app2)
+
 ## Running locally
 
 ### Prerequisites:


### PR DESCRIPTION
The travis output throws a notification about rate limiting in the before_script output, so I had a google and found that more people have hit the same problem: https://github.com/angular/webdriver-manager/issues/216

I've added the suggested fix (disable gecko) but I don't know if your tests *use* gecko, so this may be the wrong way to go about it.

In any case, I've also appended `|| exit 1` to the before_script commands that might fail, which *should* cause the tests to fail early if the setup errors out for some reason.

I see you're caching bower stuff, so if you do need the full selenium perhaps you could cache that also and reduce reliance on the internet not sucking.