### PR TITLE
[OPS-5444] fix duplicate log lines

### DIFF
--- a/nginx.default.conf
+++ b/nginx.default.conf
@@ -3,8 +3,6 @@ log_format logstash '$remote_addr - $remote_user [$time_local] "$request" '
   '$status $body_bytes_sent "$http_referer" "$http_user_agent" '
   '$request_time $http_host $http_x_forwarded_proto';
 
-access_log /var/log/nginx/access.log logstash;
-
 gzip on;
 gzip_disable "MSIE [1-6]\.(?!.*SV1)";
 gzip_proxied any;
@@ -31,5 +29,6 @@ server {
 
     location / {
         try_files $uri $uri/ /index.html =404;
+        access_log /var/log/nginx/access.log logstash;
     }
 }

--- a/nginx.default.conf
+++ b/nginx.default.conf
@@ -23,12 +23,13 @@ server {
     root /srv/www/html;
     index index.html;
 
+    access_log /var/log/nginx/access.log logstash;
+
     location /favicon.ico {
         log_not_found off;
     }
 
     location / {
         try_files $uri $uri/ /index.html =404;
-        access_log /var/log/nginx/access.log logstash;
     }
 }


### PR DESCRIPTION
There is a rather strange way of nginx to inherit the access_log from `http` to `server` and `location` levels.

