### PR TITLE
HID-1824: fix typo with UserExportController

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -115,7 +115,7 @@
         <script src="app/components/user/UserEditController.js"></script>
         <script src="app/components/user/usersList.js"></script>
         <script src="app/components/user/UserOptionsController.js"></script>
-        <script src="app/components/user/UsersExportController.js"></script>
+        <script src="app/components/user/UserExportController.js"></script>
         <script src="app/components/user/UserListsService.js"></script>
         <script src="app/components/user/TwoFactorAuthService.js"></script>
         <script src="app/components/checkin/app.checkin.js"></script>


### PR DESCRIPTION
During work following the big linting PR #154 I noticed errors like this: https://code.angularjs.org/1.7.8/docs/error/$controller/ctrlreg?p0=UserExportController

I combed our `src/index.html` and realized it was a simple typo.