### PR TITLE
Update npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid_app2",
-  "version": "0.1.2",
+  "version": "2.1.54",
   "description": "HID Client application",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@bower_components/angular": "angular/bower-angular#^1.7.5",
     "@bower_components/angular-bootstrap": "angular-ui/bootstrap-bower#~1.3.3",
-    "@bower_components/angular-clipboard": "omichelsen/angular-clipboard#^1.6.2",
+    "@bower_components/angular-clipboard": "omichelsen/angular-clipboard#^1.7.0",
     "@bower_components/angular-file-saver": "alferov/angular-file-saver#^1.1.3",
     "@bower_components/angular-gettext": "rubenv/angular-gettext#^2.4.1",
     "@bower_components/angular-google-gapi": "maximepvrt/angular-google-gapi#^1.0.1",
@@ -91,6 +91,7 @@
     "@bower_components/offline": "HubSpot/offline#~0.7.18",
     "@bower_components/ua-parser-js": "faisalman/ua-parser-js#^0.7.17",
     "autoprefixer": "^9.6.0",
+    "union-value": ">=2.0.1",
     "grunt-postcss": "^0.9.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -101,7 +101,7 @@
   version "1.3.3"
   resolved "https://codeload.github.com/angular-ui/bootstrap-bower/tar.gz/5d53287668135dbc1acfc3a0d453cd94b5311c3c"
 
-"@bower_components/angular-clipboard@omichelsen/angular-clipboard#^1.6.2":
+"@bower_components/angular-clipboard@omichelsen/angular-clipboard#^1.7.0":
   version "1.7.0"
   resolved "https://codeload.github.com/omichelsen/angular-clipboard/tar.gz/76a6146967c3eb92ec2a70c3e303d44c94ba8eb5"
 
@@ -2094,6 +2094,13 @@ get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
+
+get-value@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/get-value/-/get-value-3.0.1.tgz#5efd2a157f1d6a516d7524e124ac52d0a39ef5a8"
+  integrity sha512-mKZj9JLQrwMBtj5wxi6MH8Z5eSKaERpAwjg43dPtlGI1ZVEgH/qC7T8/6R2OBSUA+zzHBZgICsVJaEIV2tKTDA==
+  dependencies:
+    isobject "^3.0.1"
 
 getobject@~0.1.0:
   version "0.1.0"
@@ -4551,6 +4558,13 @@ set-value@^2.0.0:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
+set-value@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-3.0.1.tgz#52c82af7653ba69eb1db92e81f5cdb32739b9e95"
+  integrity sha512-w6n3GUPYAWQj4ZyHWzD7K2FnFXHx9OTwJYbWg+6nXjG8sCLfs9DGv+KlqglKIIJx+ks7MlFuwFW2RBPb+8V+xg==
+  dependencies:
+    is-plain-object "^2.0.4"
+
 setprototypeof@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
@@ -5155,6 +5169,14 @@ underscore@~1.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
   integrity sha1-YaajIBBiKvoHljvzJSA88SI51gQ=
+
+union-value@>=2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/union-value/-/union-value-2.0.1.tgz#4e1ab0f99ab52c52a53e14d8039b5130fef682b8"
+  integrity sha512-NmcRHHhUy1qWmp6yYWsaURV2qwfS24TmTtO9S9x0L41wCNNVBQFD3toOzO0cd8SsNrFhbw/O0iYO5uffXGYocw==
+  dependencies:
+    get-value "^3.0.1"
+    set-value "^3.0.0"
 
 union-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This one took me a while, but I finally upgraded the chain of packages using the dependency that needed an update. The only thing affect AFAICT is `angular-clipboard` which is used for the "Copy" button after enabling 2FA.

I tested that part of the prefs and it all seems to work.

The remaining `set-value@0.4.3` is within the karma toolset and that's a local/CI builder-bot dependency. Not on public website.