### PR TITLE
HID-1813: suppress modal when list isn't found

### DIFF
--- a/src/app/common/errors.controller.js
+++ b/src/app/common/errors.controller.js
@@ -52,7 +52,7 @@
 
       // List not found — the template shows a good error message so we will
       // suppress the modal from displaying.
-      if (rejection.config.method === 'GET' && rejection.config.url.indexOf('/list/')) {
+      if (rejection.config.method === 'GET' && rejection.config.url.indexOf('/list/') && rejection.status === 400) {
         return NO_MODAL_DISPLAY;
       }
 

--- a/src/app/common/errors.controller.js
+++ b/src/app/common/errors.controller.js
@@ -8,6 +8,10 @@
   ErrorsCtrl.$inject = ['$rootScope', 'alertService', 'config', 'gettextCatalog'];
 
   function ErrorsCtrl($rootScope, alertService, config, gettextCatalog) {
+    // Some errors are better handled by other parts of the app (e.g. a template
+    // or other custom handling of errors). This variable lets us suppress the
+    // modal when such specific cases are caught.
+    var NO_MODAL_DISPLAY = 'no-modal-display';
 
     function getErrorMessage (rejection) {
 
@@ -46,6 +50,12 @@
         return gettextCatalog.getString('There is an error in your registration. You may have already registered. If so, simply <a href="/password_reset" target="_top">reset your password</a>.');
       }
 
+      // List not found — the template shows a good error message so we will
+      // suppress the modal from displaying.
+      if (rejection.config.method === 'GET' && rejection.config.url.indexOf('/list/')) {
+        return NO_MODAL_DISPLAY;
+      }
+
       // Return error message from API
       if (rejection.data && rejection.data.message) {
         return rejection.data.message;
@@ -62,7 +72,8 @@
 
     $rootScope.$on('apiRejection', function (event, rejection) {
       var errorMessage = getErrorMessage(rejection);
-      if (errorMessage) {
+
+      if (errorMessage && errorMessage !== NO_MODAL_DISPLAY) {
         alertService.add('danger', errorMessage, false, null, 0);
       }
     });

--- a/src/app/common/errors.controller.js
+++ b/src/app/common/errors.controller.js
@@ -51,8 +51,9 @@
       }
 
       // List not found — the template shows a good error message so we will
-      // suppress the modal from displaying.
-      if (rejection.config.method === 'GET' && rejection.config.url.indexOf('/list/') && rejection.status === 400) {
+      // suppress the modal from displaying if the ID is non-existent or invalid.
+      var listNotFoundStatuses = [400, 404];
+      if (rejection.config.method === 'GET' && rejection.config.url.indexOf('/list/') && listNotFoundStatuses.indexOf(rejection.status) !== -1) {
         return NO_MODAL_DISPLAY;
       }
 

--- a/src/po/template.pot
+++ b/src/po/template.pot
@@ -1904,7 +1904,7 @@ msgstr ""
 msgid "Some of you check-ins are pending, we will get back to you soon."
 msgstr ""
 
-#: src/app/common/errors.controller.js:66
+#: src/app/common/errors.controller.js:67
 msgid "Sorry there was an problem making this request, please try again"
 msgstr ""
 

--- a/src/po/template.pot
+++ b/src/po/template.pot
@@ -1904,7 +1904,7 @@ msgstr ""
 msgid "Some of you check-ins are pending, we will get back to you soon."
 msgstr ""
 
-#: src/app/common/errors.controller.js:56
+#: src/app/common/errors.controller.js:63
 msgid "Sorry there was an problem making this request, please try again"
 msgstr ""
 
@@ -2066,11 +2066,11 @@ msgstr ""
 msgid "The user was successfully unsubscribed from this service"
 msgstr ""
 
-#: src/app/common/errors.controller.js:46
+#: src/app/common/errors.controller.js:47
 msgid "There is an error in your registration. You may have already registered. If so, simply <a href=\"/password_reset\" target=\"_top\">reset your password</a>."
 msgstr ""
 
-#: src/app/common/errors.controller.js:41
+#: src/app/common/errors.controller.js:42
 msgid "There was an error logging in."
 msgstr ""
 
@@ -2316,19 +2316,19 @@ msgstr ""
 msgid "View as PDF"
 msgstr ""
 
-#: src/app/common/errors.controller.js:22
+#: src/app/common/errors.controller.js:23
 msgid "We could not log you in because your email address is not verified yet."
 msgstr ""
 
-#: src/app/common/errors.controller.js:34
+#: src/app/common/errors.controller.js:35
 msgid "We could not log you in because your password is expired. Following UN regulations, as a security measure passwords must be updated every six months. Kindly reset your password by clicking on the \"Forgot/Reset password\" link below."
 msgstr ""
 
-#: src/app/common/errors.controller.js:30
+#: src/app/common/errors.controller.js:31
 msgid "We could not log you in, the email address does not exist."
 msgstr ""
 
-#: src/app/common/errors.controller.js:26
+#: src/app/common/errors.controller.js:27
 msgid "We could not log you in. The username or password you have entered are incorrect. Kindly try again."
 msgstr ""
 
@@ -2464,7 +2464,7 @@ msgstr ""
 msgid "You were successfully unsubscribed from this service"
 msgstr ""
 
-#: src/app/common/errors.controller.js:16
+#: src/app/common/errors.controller.js:17
 msgid "You've reached the API request limit, please try again in 10 minutes"
 msgstr ""
 
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Your API keys"
 msgstr ""
 
-#: src/app/common/errors.controller.js:38
+#: src/app/common/errors.controller.js:39
 msgid "Your account has been locked for 5 minutes due to too many unsuccessful login attempts"
 msgstr ""
 

--- a/src/po/template.pot
+++ b/src/po/template.pot
@@ -1904,7 +1904,7 @@ msgstr ""
 msgid "Some of you check-ins are pending, we will get back to you soon."
 msgstr ""
 
-#: src/app/common/errors.controller.js:63
+#: src/app/common/errors.controller.js:66
 msgid "Sorry there was an problem making this request, please try again"
 msgstr ""
 
@@ -2066,11 +2066,11 @@ msgstr ""
 msgid "The user was successfully unsubscribed from this service"
 msgstr ""
 
-#: src/app/common/errors.controller.js:47
+#: src/app/common/errors.controller.js:50
 msgid "There is an error in your registration. You may have already registered. If so, simply <a href=\"/password_reset\" target=\"_top\">reset your password</a>."
 msgstr ""
 
-#: src/app/common/errors.controller.js:42
+#: src/app/common/errors.controller.js:45
 msgid "There was an error logging in."
 msgstr ""
 
@@ -2316,19 +2316,19 @@ msgstr ""
 msgid "View as PDF"
 msgstr ""
 
-#: src/app/common/errors.controller.js:23
+#: src/app/common/errors.controller.js:26
 msgid "We could not log you in because your email address is not verified yet."
 msgstr ""
 
-#: src/app/common/errors.controller.js:35
+#: src/app/common/errors.controller.js:38
 msgid "We could not log you in because your password is expired. Following UN regulations, as a security measure passwords must be updated every six months. Kindly reset your password by clicking on the \"Forgot/Reset password\" link below."
 msgstr ""
 
-#: src/app/common/errors.controller.js:31
+#: src/app/common/errors.controller.js:34
 msgid "We could not log you in, the email address does not exist."
 msgstr ""
 
-#: src/app/common/errors.controller.js:27
+#: src/app/common/errors.controller.js:30
 msgid "We could not log you in. The username or password you have entered are incorrect. Kindly try again."
 msgstr ""
 
@@ -2464,7 +2464,7 @@ msgstr ""
 msgid "You were successfully unsubscribed from this service"
 msgstr ""
 
-#: src/app/common/errors.controller.js:17
+#: src/app/common/errors.controller.js:20
 msgid "You've reached the API request limit, please try again in 10 minutes"
 msgstr ""
 
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Your API keys"
 msgstr ""
 
-#: src/app/common/errors.controller.js:39
+#: src/app/common/errors.controller.js:42
 msgid "Your account has been locked for 5 minutes due to too many unsuccessful login attempts"
 msgstr ""
 


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/HID-1813

The UX of the "list not found" page is better than the modal itself, so we suppress showing it and rely only on the template to direct a visitor to the next step.

@guillaumev I believe I got the conditions for this API request pretty specific but would love your 👀 on it to ensure I didn't accidentally suppress modals on other situations.