### PR TITLE
HID-1806: dedupe authorized clients list when displaying to admins

### DIFF
--- a/src/app/components/user/user.controller.js
+++ b/src/app/components/user/user.controller.js
@@ -209,10 +209,10 @@
 
     function dedupeAuthorizedClients(clients) {
       $scope.user.authorizedClients = clients.filter(function dedupe(client, index, self) {
-        var dupeIndex = self.findIndex(function (c) {
+        var firstIndexFound = self.findIndex(function (c) {
           return c._id === client._id && c.name === client.name;
         });
-        return dupeIndex === index;
+        return firstIndexFound === index;
       });
     }
 

--- a/src/app/components/user/user.controller.js
+++ b/src/app/components/user/user.controller.js
@@ -172,6 +172,7 @@
         setConnectionInfo($scope.user, $scope.currentUser._id);
         authUserAlert($scope.user, $scope.currentUser);
         setVcardUrl($scope.user);
+        dedupeAuthorizedClients($scope.user.authorizedClients);
         if (!$scope.currentUser.verified && $scope.user.is_orphan) {
           $scope.canViewInfo = false;
           alertService.pageAlert('warning', gettextCatalog.getString('In order to view this person’s profile, please contact info@humanitarian.id'));
@@ -205,6 +206,15 @@
         });
     }
     getUser();
+
+    function dedupeAuthorizedClients(clients) {
+      $scope.user.authorizedClients = clients.filter(function dedupe(client, index, self) {
+        var dupeIndex = self.findIndex(function (c) {
+          return c._id === client._id && c.name === client.name;
+        });
+        return dupeIndex === index;
+      });
+    }
 
     //Listen for user edited event
     $scope.$on('editUser', function (event, data) {

--- a/src/po/template.pot
+++ b/src/po/template.pot
@@ -214,7 +214,7 @@ msgstr ""
 msgid "Are you sure you want to do this ? You will not be able to access Humanitarian ID anymore."
 msgstr ""
 
-#: src/app/components/user/user.controller.js:321
+#: src/app/components/user/user.controller.js:331
 #: src/app/components/user/userOptions.controller.js:23
 msgid "Are you sure you want to do this? This user will not be able to access Humanitarian ID anymore."
 msgstr ""
@@ -356,7 +356,7 @@ msgstr ""
 msgid "Civil-Military Officer"
 msgstr ""
 
-#: src/app/components/user/user.controller.js:247
+#: src/app/components/user/user.controller.js:257
 msgid "Claim email sent successfully"
 msgstr ""
 
@@ -441,7 +441,7 @@ msgstr ""
 msgid "Connection removed"
 msgstr ""
 
-#: src/app/components/user/user.controller.js:334
+#: src/app/components/user/user.controller.js:344
 msgid "Connection request sent"
 msgstr ""
 
@@ -953,7 +953,7 @@ msgstr ""
 msgid "If your organization is not listed, click <a href=\"https://docs.google.com/a/humanitarianresponse.info/forms/d/e/1FAIpQLSdpkMue4gFydSm1PwhSIQonpWRGG50ouJJdo8NbcvaMv_pcDw/viewform?c=0&w=1\" target=\"_blank\">here</a> to request adding it."
 msgstr ""
 
-#: src/app/components/user/user.controller.js:177
+#: src/app/components/user/user.controller.js:178
 msgid "In order to view this person’s profile, please contact info@humanitarian.id"
 msgstr ""
 
@@ -2051,7 +2051,7 @@ msgstr ""
 msgid "The user was successfully created. If you inserted an email address, they will receive an email to claim their account. You can now edit the user profile to add more information."
 msgstr ""
 
-#: src/app/components/user/user.controller.js:314
+#: src/app/components/user/user.controller.js:324
 #: src/app/components/user/userOptions.controller.js:17
 msgid "The user was successfully deleted."
 msgstr ""
@@ -2241,14 +2241,14 @@ msgstr ""
 msgid "User not found"
 msgstr ""
 
-#: src/app/components/user/user.controller.js:263
-#: src/app/components/user/user.controller.js:278
-#: src/app/components/user/user.controller.js:300
+#: src/app/components/user/user.controller.js:273
+#: src/app/components/user/user.controller.js:288
+#: src/app/components/user/user.controller.js:310
 #: src/app/components/user/userOptions.controller.js:37
 msgid "User updated"
 msgstr ""
 
-#: src/app/components/user/user.controller.js:238
+#: src/app/components/user/user.controller.js:248
 msgid "User was successfully notified"
 msgstr ""
 


### PR DESCRIPTION
## https://humanitarian.atlassian.net/browse/HID-1806

We already determined that it wasn't harming anything, but this PR fixes the glitch where an authorized client shows up twice in the admin-only block of a profile.

### Before / After

<img src="https://user-images.githubusercontent.com/254753/66634257-f96ddc00-ec0c-11e9-8dba-7b24f6936068.png" width="49%"> <img src="https://user-images.githubusercontent.com/254753/66634261-fc68cc80-ec0c-11e9-8d15-b3cb6a327577.png" width="49%">

