### PR TITLE
HID-1868: PDF footer

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -258,6 +258,11 @@ module.exports = function(grunt) {
     'copy:config'
   ]);
 
+  grunt.registerTask('sass-api', [
+    'sass:api',
+    'postcss',
+  ]);
+
   // Default task
   grunt.registerTask('default', [
     'svgmin',

--- a/src/assets/css/api.scss
+++ b/src/assets/css/api.scss
@@ -127,7 +127,7 @@
   font-weight: bold;
   @include font-size($small-font-size);
   width: 100%;
-  text-align: right;
+  text-align: left;
   padding-bottom: $base-unit/2;
 }
 


### PR DESCRIPTION
## HID-1868 & HID-1822

Following up a hotfix with more permanent solution to the problem. Added a dedicated Grunt task for the API Sass as well, incorporating autoprefixing for better IE11 support.