### PR TITLE
set correct node version for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "8.11.3"
+  - "10.14.2"
 dist: trusty
 addons:
   apt:


### PR DESCRIPTION
Travis for #189 can't run at all because we never updated node version in the Travis file.