### PR TITLE
HID-1880: SVG sprites should use symbol definition without URL prefix

### DIFF
--- a/src/app/common/icon.js
+++ b/src/app/common/icon.js
@@ -38,7 +38,7 @@
     };
 
     function iconUrl (name) {
-      return $window.location.origin + $window.location.pathname + '#icon-' + name;
+      return '#icon-' + name;
     }
 
     return directive;


### PR DESCRIPTION
## HID-1880

This was a weird one and I don't understand why one page of the site had troubles when others were fine, but at least this brings the component in line with other popular examples on the web.