### PR TITLE
Followup Release 2019-11-25

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid_app2",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "HID Client application",
   "main": "index.js",
   "scripts": {

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="no-js" lang="" ng-app="hidApp" manifest="/offline.appcache">
+<html class="no-js" lang="" ng-app="hidApp" manifest="/decomissioned.appcache">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">


### PR DESCRIPTION
AppCache caused problems and I opted to disable it entirely by pointing to a 404. The grunt task is still there so if it causes problems with other offline functionality we can re-enable by pointing at the real Manifest URL again.