### PR TITLE
HID-1967: use password-specific method to update password within v2

### DIFF
--- a/src/app/components/user/User.js
+++ b/src/app/components/user/User.js
@@ -259,7 +259,7 @@
     User.prototype.changePassword = function (user, success, error, token) {
       var req = {
         method: 'PUT',
-        url: config.apiUrl + 'user/' + user._id,
+        url: config.apiUrl + 'user/' + user._id + '/password',
         data: user,
         headers: {
           'X-HID-TOTP': token


### PR DESCRIPTION
# HID-1967

Use password-specific method to update user password. This unblocks further improvements to the API by lessening (or perhaps eliminating) the actual breaking changes.