### PR TITLE
HID-2085: remove prompt to manually verify from landing page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid_app2",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "HID Client application",
   "main": "index.js",
   "scripts": {

--- a/src/app/components/landing/landing.html
+++ b/src/app/components/landing/landing.html
@@ -156,16 +156,9 @@
           <icon name="arrow-right"></icon>
           <span translate>Last update of your profile</span>: <span ng-bind="currentUser.lastModified | date:'longDate'"></span>
         </li>
-          <li class="secondary-block__item secondary-block__item--has-icon">
-            <icon name="arrow-right"></icon>
-            <span ng-if="currentUser.verified" translate>Your profile has been verified.</span>
-            <span ng-if="!currentUser.verified" translate>Your profile is not verified.</span>
-            <a href="https://about.humanitarian.id/faqs#verification" ng-if="!currentUser.verified" target="_blank" translate>Learn how to verify it</a>
-          </li>
-        </ul>
-
-      </div>
-
+      </ul>
     </div>
   </div>
+</div>
+
 </div>

--- a/src/po/template.pot
+++ b/src/po/template.pot
@@ -1022,10 +1022,6 @@ msgstr ""
 msgid "Last update of your profile"
 msgstr ""
 
-#: src/app/components/landing/landing.html:163
-msgid "Learn how to verify it"
-msgstr ""
-
 #: src/app/components/trustedDomain/trustedDomains.html:44
 msgid "List"
 msgstr ""
@@ -2564,14 +2560,6 @@ msgstr ""
 
 #: src/app/common/messages.html:2
 msgid "Your passwords do not match"
-msgstr ""
-
-#: src/app/components/landing/landing.html:161
-msgid "Your profile has been verified."
-msgstr ""
-
-#: src/app/components/landing/landing.html:162
-msgid "Your profile is not verified."
 msgstr ""
 
 #: src/app/components/list/list.html:97


### PR DESCRIPTION
# HID-2085

We don't want to remind users about manual verification anymore. Both verified/unverified user will no longer see a message about their status on the landing page after login.