### PR TITLE
HID-2096: native app wrapper decomission message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid_app2",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "description": "HID Client application",
   "main": "index.js",
   "scripts": {

--- a/src/app/components/auth/AuthController.js
+++ b/src/app/components/auth/AuthController.js
@@ -13,6 +13,12 @@
     thisScope.saving = false;
     var twoFAModal;
 
+    if ($window.navigator.userAgent.indexOf('Cordova') !== -1) {
+      thisScope.nativeApp = true;
+    } else {
+      thisScope.nativeApp = false;
+    }
+
     function onFirstLogin () {
       thisScope.currentUser.setAppMetaData({login: true});
       thisScope.currentUser.authOnly = false;

--- a/src/app/components/auth/login.html
+++ b/src/app/components/auth/login.html
@@ -1,3 +1,9 @@
+<div class="row" ng-if="nativeApp">
+  <div class="col-xs-12">
+    <p class="alert alert--inline alert--danger" translate>In January 2021, the Humanitarian ID website and app will be decommissioned. Your HID account will remain valid as part of the stand-alone HID Authentication service which can be used to login to any of the partner platforms. More information about this decommissioning is available in the <a href="https://about.humanitarian.id/faqs#contacts-decommissioning">FAQs section</a>.</p>
+  </div>
+</div>
+
 <div class="row" class="login">
   <div class="col-sm-8 offset-sm-2 col-md-6 offset-md-3 col-lg-6 offset-lg-0">
     <div class="page-header page-header--login">

--- a/src/app/components/landing/LandingController.js
+++ b/src/app/components/landing/LandingController.js
@@ -5,9 +5,9 @@
     .module('app.dashboard')
     .controller('LandingController', LandingController);
 
-  LandingController.$inject = ['$location', '$scope', 'notificationsService'];
+  LandingController.$inject = ['$window', '$location', '$scope', 'notificationsService'];
 
-  function LandingController($location, $scope, notificationsService) {
+  function LandingController($window, $location, $scope, notificationsService) {
     var thisScope = $scope;
     thisScope.notifications = notificationsService;
 
@@ -16,7 +16,6 @@
     thisScope.recentOperationSearches = [];
 
     if (thisScope.currentUser.appMetadata && thisScope.currentUser.appMetadata.hid && thisScope.currentUser.appMetadata.hid.recentSearches) {
-
       if (thisScope.currentUser.appMetadata.hid.recentSearches.user) {
         thisScope.recentUserSearches = thisScope.currentUser.appMetadata.hid.recentSearches.user;
       }
@@ -28,7 +27,12 @@
       if (thisScope.currentUser.appMetadata.hid.recentSearches.operation) {
         thisScope.recentOperationSearches = thisScope.currentUser.appMetadata.hid.recentSearches.operation;
       }
+    }
 
+    if ($window.navigator.userAgent.indexOf('Cordova') !== -1) {
+      thisScope.nativeApp = true;
+    } else {
+      thisScope.nativeApp = false;
     }
 
     thisScope.readNotification = function (notification) {

--- a/src/app/components/landing/landing.html
+++ b/src/app/components/landing/landing.html
@@ -1,3 +1,9 @@
+<div class="row" ng-if="nativeApp">
+  <div class="col-xs-12">
+    <p class="alert alert--inline alert--danger" translate>In January 2021, the Humanitarian ID website and app will be decommissioned. Your HID account will remain valid as part of the stand-alone HID Authentication service which can be used to login to any of the partner platforms. More information about this decommissioning is available in the <a href="https://about.humanitarian.id/faqs#contacts-decommissioning">FAQs section</a>.</p>
+  </div>
+</div>
+
 <div class="row">
   <div class="col-xs-12">
     <div class="page-header page-header--no-actions">

--- a/src/app/config/config.dev.js
+++ b/src/app/config/config.dev.js
@@ -2,7 +2,7 @@
   window.__env = window.__env || {};
 
   // API url
-  window.__env.apiUrl = 'https://api.dev.humanitarian.id/api/v2/';
+  window.__env.apiUrl = 'https://dev.api-humanitarian-id.ahconu.org/api/v2/';
 
   // Hrinfo url
   window.__env.hrinfoUrl = 'https://www.humanitarianresponse.info/en/api/v1.0/';
@@ -11,7 +11,7 @@
   window.__env.listTypes = ['operation', 'bundle', 'disaster', 'organization', 'list', 'functional_role', 'office'];
 
   //Google Analytics tracking ID
-  window.__env.gaTrackingId = 'UA-60189654-1'
+  window.__env.gaTrackingId = 'UA-XXXXXXXX-X'
 
 }(this));
 

--- a/src/app/config/config.staging.js
+++ b/src/app/config/config.staging.js
@@ -2,7 +2,7 @@
   window.__env = window.__env || {};
 
   // API url
-  window.__env.apiUrl = 'https://api.staging.humanitarian.id/api/v2/';
+  window.__env.apiUrl = 'https://stage.api-humanitarian-id.ahconu.org/api/v2/';
 
   // Hrinfo url
   window.__env.hrinfoUrl = 'https://www.humanitarianresponse.info/en/api/v1.0/';

--- a/src/po/template.pot
+++ b/src/po/template.pot
@@ -698,7 +698,7 @@ msgstr ""
 msgid "Edit service"
 msgstr ""
 
-#: src/app/components/auth/login.html:9
+#: src/app/components/auth/login.html:15
 #: src/app/components/auth/password_reset.html:10
 #: src/app/components/user/kiosk.html:127
 #: src/app/components/user/kiosk.html:27
@@ -824,7 +824,7 @@ msgstr ""
 msgid "Flag suspicious user"
 msgstr ""
 
-#: src/app/components/auth/login.html:23
+#: src/app/components/auth/login.html:29
 msgid "Forgot/Reset password"
 msgstr ""
 
@@ -942,6 +942,7 @@ msgstr ""
 msgid "If you want to join a list temporarily, add a check-out date. We’ll send you a reminder shortly before the given date and we’ll check you out automatically at the date you specified."
 msgstr ""
 
+#: src/app/components/auth/login.html:3
 #: src/app/components/landing/landing.html:3
 msgid "In January 2021, the Humanitarian ID website and app will be decommissioned. Your HID account will remain valid as part of the stand-alone HID Authentication service which can be used to login to any of the partner platforms. More information about this decommissioning is available in the <a href=\"https://about.humanitarian.id/faqs#contacts-decommissioning\">FAQs section</a>."
 msgstr ""
@@ -1072,7 +1073,7 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: src/app/components/auth/login.html:4
+#: src/app/components/auth/login.html:10
 msgid "Log in to Humanitarian ID."
 msgstr ""
 
@@ -1080,7 +1081,7 @@ msgstr ""
 msgid "Log out"
 msgstr ""
 
-#: src/app/components/auth/login.html:19
+#: src/app/components/auth/login.html:25
 #: src/app/components/header/header.html:71
 msgid "Login"
 msgstr ""
@@ -1418,7 +1419,7 @@ msgstr ""
 msgid "Other lists you might be interested in"
 msgstr ""
 
-#: src/app/components/auth/login.html:13
+#: src/app/components/auth/login.html:19
 #: src/app/components/auth/reset_password.html:15
 #: src/app/components/user/new-user.html:24
 msgid "Password"
@@ -1569,7 +1570,7 @@ msgstr ""
 msgid "Register a Humanitarian ID account"
 msgstr ""
 
-#: src/app/components/auth/login.html:22
+#: src/app/components/auth/login.html:28
 msgid "Register a new Humanitarian ID Account"
 msgstr ""
 
@@ -2442,7 +2443,7 @@ msgstr ""
 msgid "You were successfully checked into the list"
 msgstr ""
 
-#: src/app/components/auth/AuthController.js:101
+#: src/app/components/auth/AuthController.js:107
 msgid "You were successfully logged out."
 msgstr ""
 
@@ -2509,7 +2510,7 @@ msgstr ""
 msgid "Your device lost its internet connection."
 msgstr ""
 
-#: src/app/components/auth/login.html:10
+#: src/app/components/auth/login.html:16
 #: src/app/components/auth/password_reset.html:11
 #: src/app/components/user/kiosk.html:28
 msgid "Your email address"
@@ -2532,7 +2533,7 @@ msgstr ""
 msgid "Your new password"
 msgstr ""
 
-#: src/app/components/auth/login.html:14
+#: src/app/components/auth/login.html:20
 #: src/app/components/user/new-user.html:26
 #: src/app/components/user/new-user.html:33
 msgid "Your password"

--- a/src/po/template.pot
+++ b/src/po/template.pot
@@ -234,7 +234,7 @@ msgstr ""
 msgid "Area Coordinator"
 msgstr ""
 
-#: src/app/components/landing/landing.html:145
+#: src/app/components/landing/landing.html:151
 #: src/app/components/notifications/notifications.html:11
 msgid "As of January 2021 the Humanitarian ID contact management features will be decommissioned. More information about this update is available in HID FAQs section."
 msgstr ""
@@ -942,6 +942,10 @@ msgstr ""
 msgid "If you want to join a list temporarily, add a check-out date. We’ll send you a reminder shortly before the given date and we’ll check you out automatically at the date you specified."
 msgstr ""
 
+#: src/app/components/landing/landing.html:3
+msgid "In January 2021, the Humanitarian ID website and app will be decommissioned. Your HID account will remain valid as part of the stand-alone HID Authentication service which can be used to login to any of the partner platforms. More information about this decommissioning is available in the <a href=\"https://about.humanitarian.id/faqs#contacts-decommissioning\">FAQs section</a>."
+msgstr ""
+
 #: src/app/components/user/UserController.js:180
 msgid "In order to view this person’s profile, please contact info@humanitarian.id"
 msgstr ""
@@ -1009,7 +1013,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: src/app/components/landing/landing.html:157
+#: src/app/components/landing/landing.html:163
 msgid "Last update of your profile"
 msgstr ""
 
@@ -1322,7 +1326,7 @@ msgid ""
 "      with HID Authentication service. More info available on the <a href=\"https://about.humanitarian.id/faqs#contacts-decommissioning\" target=\"_blank\" rel=\"noopener\">FAQs page</a>."
 msgstr ""
 
-#: src/app/components/landing/landing.html:136
+#: src/app/components/landing/landing.html:142
 #: src/app/components/notifications/notifications.html:5
 msgid "Notifications"
 msgstr ""
@@ -1533,9 +1537,9 @@ msgstr ""
 msgid "Read more"
 msgstr ""
 
-#: src/app/components/landing/landing.html:121
-#: src/app/components/landing/landing.html:43
-#: src/app/components/landing/landing.html:82
+#: src/app/components/landing/landing.html:127
+#: src/app/components/landing/landing.html:49
+#: src/app/components/landing/landing.html:88
 msgid "Recent:&nbsp;"
 msgstr ""
 
@@ -1664,8 +1668,8 @@ msgstr ""
 msgid "Search for a country"
 msgstr ""
 
-#: src/app/components/landing/landing.html:64
-#: src/app/components/landing/landing.html:65
+#: src/app/components/landing/landing.html:70
+#: src/app/components/landing/landing.html:71
 msgid "Search for a country / region"
 msgstr ""
 
@@ -1675,13 +1679,13 @@ msgstr ""
 msgid "Search for a list"
 msgstr ""
 
-#: src/app/components/landing/landing.html:102
-#: src/app/components/landing/landing.html:103
+#: src/app/components/landing/landing.html:108
+#: src/app/components/landing/landing.html:109
 msgid "Search for a list name"
 msgstr ""
 
-#: src/app/components/landing/landing.html:24
-#: src/app/components/landing/landing.html:25
+#: src/app/components/landing/landing.html:30
+#: src/app/components/landing/landing.html:31
 #: src/app/components/user/user.html:82
 #: src/app/components/user/user.html:83
 msgid "Search for a name"
@@ -1695,7 +1699,7 @@ msgstr ""
 msgid "Search for an organisation"
 msgstr ""
 
-#: src/app/components/landing/landing.html:19
+#: src/app/components/landing/landing.html:25
 msgid "Search for contacts"
 msgstr ""
 
@@ -1707,11 +1711,11 @@ msgstr ""
 msgid "Search for contacts or lists"
 msgstr ""
 
-#: src/app/components/landing/landing.html:61
+#: src/app/components/landing/landing.html:67
 msgid "Search for operation lists"
 msgstr ""
 
-#: src/app/components/landing/landing.html:99
+#: src/app/components/landing/landing.html:105
 msgid "Search for other contact lists"
 msgstr ""
 
@@ -2298,10 +2302,10 @@ msgstr ""
 msgid "View Trusted Domains"
 msgstr ""
 
-#: src/app/components/landing/landing.html:116
-#: src/app/components/landing/landing.html:138
-#: src/app/components/landing/landing.html:38
-#: src/app/components/landing/landing.html:78
+#: src/app/components/landing/landing.html:122
+#: src/app/components/landing/landing.html:144
+#: src/app/components/landing/landing.html:44
+#: src/app/components/landing/landing.html:84
 #: src/app/components/user/user.html:96
 msgid "View all"
 msgstr ""
@@ -2334,7 +2338,7 @@ msgstr ""
 msgid "Websites"
 msgstr ""
 
-#: src/app/components/landing/landing.html:4
+#: src/app/components/landing/landing.html:10
 msgid "Welcome to Humanitarian ID"
 msgstr ""
 


### PR DESCRIPTION
# HID-2096

We want to show a more prominent message to "native apps" which are Cordova wrappers for our website. Added a UA check for `Cordova` as that seemed to be sufficient from a dive into our prod logs.

I also updated our config for non-prod environments to stop pointing at old Contegix API origins.