### PR TITLE
Production 2020-07-15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid_app2",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "HID Client application",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid_app2",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "description": "HID Client application",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid_app2",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "description": "HID Client application",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid_app2",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "HID Client application",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid_app2",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "HID Client application",
   "main": "index.js",
   "scripts": {

--- a/src/app/components/auth/AuthController.js
+++ b/src/app/components/auth/AuthController.js
@@ -13,6 +13,12 @@
     thisScope.saving = false;
     var twoFAModal;
 
+    if ($window.navigator.userAgent.indexOf('Cordova') !== -1) {
+      thisScope.nativeApp = true;
+    } else {
+      thisScope.nativeApp = false;
+    }
+
     function onFirstLogin () {
       thisScope.currentUser.setAppMetaData({login: true});
       thisScope.currentUser.authOnly = false;

--- a/src/app/components/auth/login.html
+++ b/src/app/components/auth/login.html
@@ -1,3 +1,9 @@
+<div class="row" ng-if="nativeApp">
+  <div class="col-xs-12">
+    <p class="alert alert--inline alert--danger" translate>In January 2021, the Humanitarian ID website and app will be decommissioned. Your HID account will remain valid as part of the stand-alone HID Authentication service which can be used to login to any of the partner platforms. More information about this decommissioning is available in the <a href="https://about.humanitarian.id/faqs#contacts-decommissioning">FAQs section</a>.</p>
+  </div>
+</div>
+
 <div class="row" class="login">
   <div class="col-sm-8 offset-sm-2 col-md-6 offset-md-3 col-lg-6 offset-lg-0">
     <div class="page-header page-header--login">

--- a/src/app/components/auth/register.html
+++ b/src/app/components/auth/register.html
@@ -1,10 +1,14 @@
 <div class="row">
 	<div class="col-sm-10 offset-sm-1 col-md-8 offset-md-2 col-lg-6 offset-lg-3">
 	  <div class="page-header">
-	    <h1 class="page-header__heading" translate>Register</h1>
+	    <h1 class="page-header__heading" translate>Register a Humanitarian ID account</h1>
 	  </div>
-	  <p class="form-field" translate>Sign up for a Humanitarian ID account. Doing so will give you access to Humanitarian ID as well as a growing number of
-			<a href="https://about.humanitarian.id/partners-using-our-authentication-service" target="_blank">related humanitarian community sites</a>.</p>
+	  <p class="form-field" translate>
+      Note: As of January 2021 the Humanitarian ID contact management features
+      on this platform will be decommissioned. However, your account will remain
+      valid to access all <a href="https://about.humanitarian.id/partners-using-our-authentication-service" target="_blank" rel="noopener">websites integrated</a>
+      with HID Authentication service. More info available on the <a href="https://about.humanitarian.id/faqs#contacts-decommissioning" target="_blank" rel="noopener">FAQs page</a>.
+    </p>
 	  <ng-include src="'app/components/user/new-user.html'"></ng-include>
 	</div>
 </div>

--- a/src/app/components/footer/footer.html
+++ b/src/app/components/footer/footer.html
@@ -6,12 +6,6 @@
           <a href="https://about.humanitarian.id/" class="footer-links__link" translate>About</a>
         </li>
         <li class="footer-links__item">
-          <a href="https://about.humanitarian.id/support/" class="footer-links__link" translate>Support</a>
-        </li>
-        <li class="footer-links__item">
-          <a href="https://about.humanitarian.id/blog/" class="footer-links__link" translate>Blog</a>
-        </li>
-        <li class="footer-links__item">
           <a href="https://about.humanitarian.id/developers/" class="footer-links__link" translate>Developers</a>
         </li>
         <li class="footer-links__item">
@@ -26,15 +20,6 @@
       </ul>
     </div>
     <div class="cd-footer__section cd-footer__section--social">
-      <a href="https://twitter.com/HumanitarianID" class="cd-footer-social__link">
-        <span class="element-invisible">Twitter</span>
-        <svg class="icon icon--twitter">
-          <use xlink:href="#sm-tt-def"></use>
-        </svg>
-        <svg class="icon icon--twitter hover-style">
-          <use xlink:href="#sm-tt-full"></use>
-        </svg>
-      </a>
       <a href="https://github.com/UN-OCHA" class="cd-footer-social__link">
         <span class="element-invisible">Github</span>
         <svg class="icon icon--github">

--- a/src/app/components/header/header.html
+++ b/src/app/components/header/header.html
@@ -86,7 +86,6 @@
             <ul class="menu" role="menu">
               <li><a href="/users/{{currentUser.id}}" class="first leaf t-profile-link" translate>Profile</a></li>
               <li><a href="/settings" class="leaf t-preferences-link" translate>Preferences</a></li>
-              <li><a href="/tutorial" class="leaf" translate>Tutorial</a></li>
               <li><a href="mailto:info@humanitarian.id" class="leaf btn-link" translate>Feedback</a></li>
               <li><a href="/logout" class="last leaf t-logout-link" translate>Log out</a></li>
             </ul>

--- a/src/app/components/landing/LandingController.js
+++ b/src/app/components/landing/LandingController.js
@@ -5,9 +5,9 @@
     .module('app.dashboard')
     .controller('LandingController', LandingController);
 
-  LandingController.$inject = ['$location', '$scope', 'notificationsService'];
+  LandingController.$inject = ['$window', '$location', '$scope', 'notificationsService'];
 
-  function LandingController($location, $scope, notificationsService) {
+  function LandingController($window, $location, $scope, notificationsService) {
     var thisScope = $scope;
     thisScope.notifications = notificationsService;
 
@@ -16,7 +16,6 @@
     thisScope.recentOperationSearches = [];
 
     if (thisScope.currentUser.appMetadata && thisScope.currentUser.appMetadata.hid && thisScope.currentUser.appMetadata.hid.recentSearches) {
-
       if (thisScope.currentUser.appMetadata.hid.recentSearches.user) {
         thisScope.recentUserSearches = thisScope.currentUser.appMetadata.hid.recentSearches.user;
       }
@@ -28,7 +27,12 @@
       if (thisScope.currentUser.appMetadata.hid.recentSearches.operation) {
         thisScope.recentOperationSearches = thisScope.currentUser.appMetadata.hid.recentSearches.operation;
       }
+    }
 
+    if ($window.navigator.userAgent.indexOf('Cordova') !== -1) {
+      thisScope.nativeApp = true;
+    } else {
+      thisScope.nativeApp = false;
     }
 
     thisScope.readNotification = function (notification) {

--- a/src/app/components/landing/landing.html
+++ b/src/app/components/landing/landing.html
@@ -156,16 +156,9 @@
           <icon name="arrow-right"></icon>
           <span translate>Last update of your profile</span>: <span ng-bind="currentUser.lastModified | date:'longDate'"></span>
         </li>
-          <li class="secondary-block__item secondary-block__item--has-icon">
-            <icon name="arrow-right"></icon>
-            <span ng-if="currentUser.verified" translate>Your profile has been verified.</span>
-            <span ng-if="!currentUser.verified" translate>Your profile is not verified.</span>
-            <a href="https://about.humanitarian.id/faqs#verification" ng-if="!currentUser.verified" target="_blank" translate>Learn how to verify it</a>
-          </li>
-        </ul>
-
-      </div>
-
+      </ul>
     </div>
   </div>
+</div>
+
 </div>

--- a/src/app/components/landing/landing.html
+++ b/src/app/components/landing/landing.html
@@ -1,3 +1,9 @@
+<div class="row" ng-if="nativeApp">
+  <div class="col-xs-12">
+    <p class="alert alert--inline alert--danger" translate>In January 2021, the Humanitarian ID website and app will be decommissioned. Your HID account will remain valid as part of the stand-alone HID Authentication service which can be used to login to any of the partner platforms. More information about this decommissioning is available in the <a href="https://about.humanitarian.id/faqs#contacts-decommissioning">FAQs section</a>.</p>
+  </div>
+</div>
+
 <div class="row">
   <div class="col-xs-12">
     <div class="page-header page-header--no-actions">

--- a/src/app/components/start/start.html
+++ b/src/app/components/start/start.html
@@ -41,7 +41,6 @@
 							</ui-select-choices>
 						</ui-select>
 					</div>
-					<p translate>If your organization is not listed, click <a href="https://docs.google.com/a/humanitarianresponse.info/forms/d/e/1FAIpQLSdpkMue4gFydSm1PwhSIQonpWRGG50ouJJdo8NbcvaMv_pcDw/viewform?c=0&w=1" target="_blank">here</a> to request adding it.</p>
 				</div>
 
 				<div class="form-field">

--- a/src/app/components/user/user.html
+++ b/src/app/components/user/user.html
@@ -461,7 +461,6 @@
                 <icon name="plus" text="Add"></icon>
               </button>
             </div>
-            <p translate>If your organization is not listed, click <a href="https://docs.google.com/a/humanitarianresponse.info/forms/d/e/1FAIpQLSdpkMue4gFydSm1PwhSIQonpWRGG50ouJJdo8NbcvaMv_pcDw/viewform?c=0&w=1" target="_blank">here</a> to request adding it.</p>
           </form>
 
           <form ng-if="user.organizations.length" class="form-section__edit">

--- a/src/app/components/user/user.html
+++ b/src/app/components/user/user.html
@@ -133,8 +133,6 @@
           </ul>
 
           <p class="profile-header__status">{{user.status}}</p>
-          <p class="profile-header__verified-text" ng-show="user.verified"><icon name="check-circle"></icon>This user has been verified.</p>
-          <p class="profile-header__unverified" ng-show="!user.verified"><icon name="cancel-circle"></icon>This user has not been verified. Learn how to verify a profile <a href="https://about.humanitarian.id/faqs/" target="_blank">here</a></p>
           <p class="profile-header__hidden-text" ng-show="user.hidden && (currentUser.is_admin || currentUser._id == user._id)"><icon name="eye-hidden"></icon>This user is hidden.</p>
         </div>
 

--- a/src/app/config/config.dev.js
+++ b/src/app/config/config.dev.js
@@ -2,7 +2,7 @@
   window.__env = window.__env || {};
 
   // API url
-  window.__env.apiUrl = 'https://api.dev.humanitarian.id/api/v2/';
+  window.__env.apiUrl = 'https://dev.api-humanitarian-id.ahconu.org/api/v2/';
 
   // Hrinfo url
   window.__env.hrinfoUrl = 'https://www.humanitarianresponse.info/en/api/v1.0/';
@@ -11,7 +11,7 @@
   window.__env.listTypes = ['operation', 'bundle', 'disaster', 'organization', 'list', 'functional_role', 'office'];
 
   //Google Analytics tracking ID
-  window.__env.gaTrackingId = 'UA-60189654-1'
+  window.__env.gaTrackingId = 'UA-XXXXXXXX-X'
 
 }(this));
 

--- a/src/app/config/config.staging.js
+++ b/src/app/config/config.staging.js
@@ -2,7 +2,7 @@
   window.__env = window.__env || {};
 
   // API url
-  window.__env.apiUrl = 'https://api.staging.humanitarian.id/api/v2/';
+  window.__env.apiUrl = 'https://stage.api-humanitarian-id.ahconu.org/api/v2/';
 
   // Hrinfo url
   window.__env.hrinfoUrl = 'https://www.humanitarianresponse.info/en/api/v1.0/';

--- a/src/assets/css/api.scss
+++ b/src/assets/css/api.scss
@@ -45,7 +45,7 @@
 // @import '../../app/common/_styleguide';
 @import '../../app/common/_tables';
 // @import '../../app/common/_tags';
-// @import '../../app/components/alerts/_alerts';
+@import '../../app/components/alerts/_alerts';
 @import '../../app/components/auth/_login';
 // @import '../../app/components/checkin/_checkin';
 // @import '../../app/components/dashboard/_dashboard';

--- a/src/po/template.pot
+++ b/src/po/template.pot
@@ -698,7 +698,7 @@ msgstr ""
 msgid "Edit service"
 msgstr ""
 
-#: src/app/components/auth/login.html:9
+#: src/app/components/auth/login.html:15
 #: src/app/components/auth/password_reset.html:10
 #: src/app/components/user/kiosk.html:127
 #: src/app/components/user/kiosk.html:27
@@ -824,7 +824,7 @@ msgstr ""
 msgid "Flag suspicious user"
 msgstr ""
 
-#: src/app/components/auth/login.html:23
+#: src/app/components/auth/login.html:29
 msgid "Forgot/Reset password"
 msgstr ""
 
@@ -942,6 +942,7 @@ msgstr ""
 msgid "If you want to join a list temporarily, add a check-out date. We’ll send you a reminder shortly before the given date and we’ll check you out automatically at the date you specified."
 msgstr ""
 
+#: src/app/components/auth/login.html:3
 #: src/app/components/landing/landing.html:3
 msgid "In January 2021, the Humanitarian ID website and app will be decommissioned. Your HID account will remain valid as part of the stand-alone HID Authentication service which can be used to login to any of the partner platforms. More information about this decommissioning is available in the <a href=\"https://about.humanitarian.id/faqs#contacts-decommissioning\">FAQs section</a>."
 msgstr ""
@@ -1072,7 +1073,7 @@ msgstr ""
 msgid "Locations"
 msgstr ""
 
-#: src/app/components/auth/login.html:4
+#: src/app/components/auth/login.html:10
 msgid "Log in to Humanitarian ID."
 msgstr ""
 
@@ -1080,7 +1081,7 @@ msgstr ""
 msgid "Log out"
 msgstr ""
 
-#: src/app/components/auth/login.html:19
+#: src/app/components/auth/login.html:25
 #: src/app/components/header/header.html:71
 msgid "Login"
 msgstr ""
@@ -1418,7 +1419,7 @@ msgstr ""
 msgid "Other lists you might be interested in"
 msgstr ""
 
-#: src/app/components/auth/login.html:13
+#: src/app/components/auth/login.html:19
 #: src/app/components/auth/reset_password.html:15
 #: src/app/components/user/new-user.html:24
 msgid "Password"
@@ -1569,7 +1570,7 @@ msgstr ""
 msgid "Register a Humanitarian ID account"
 msgstr ""
 
-#: src/app/components/auth/login.html:22
+#: src/app/components/auth/login.html:28
 msgid "Register a new Humanitarian ID Account"
 msgstr ""
 
@@ -2442,7 +2443,7 @@ msgstr ""
 msgid "You were successfully checked into the list"
 msgstr ""
 
-#: src/app/components/auth/AuthController.js:101
+#: src/app/components/auth/AuthController.js:107
 msgid "You were successfully logged out."
 msgstr ""
 
@@ -2509,7 +2510,7 @@ msgstr ""
 msgid "Your device lost its internet connection."
 msgstr ""
 
-#: src/app/components/auth/login.html:10
+#: src/app/components/auth/login.html:16
 #: src/app/components/auth/password_reset.html:11
 #: src/app/components/user/kiosk.html:28
 msgid "Your email address"
@@ -2532,7 +2533,7 @@ msgstr ""
 msgid "Your new password"
 msgstr ""
 
-#: src/app/components/auth/login.html:14
+#: src/app/components/auth/login.html:20
 #: src/app/components/user/new-user.html:26
 #: src/app/components/user/new-user.html:33
 msgid "Your password"

--- a/src/po/template.pot
+++ b/src/po/template.pot
@@ -10,8 +10,8 @@ msgstr ""
 msgid "&lt; Hide"
 msgstr ""
 
-#: src/app/components/user/user.html:308
-#: src/app/components/user/user.html:354
+#: src/app/components/user/user.html:306
+#: src/app/components/user/user.html:352
 msgid "/ Not confirmed"
 msgstr ""
 
@@ -75,11 +75,11 @@ msgstr ""
 msgid "Add Service"
 msgstr ""
 
-#: src/app/components/user/user.html:506
+#: src/app/components/user/user.html:504
 msgid "Add a job title"
 msgstr ""
 
-#: src/app/components/user/user.html:504
+#: src/app/components/user/user.html:502
 msgid "Add a job title:"
 msgstr ""
 
@@ -107,16 +107,16 @@ msgstr ""
 msgid "Add a new phone number:"
 msgstr ""
 
-#: src/app/components/user/user.html:446
+#: src/app/components/user/user.html:444
 msgid "Add an organization:"
 msgstr ""
 
-#: src/app/components/user/user.html:316
+#: src/app/components/user/user.html:314
 msgid "Add email:"
 msgstr ""
 
 #: src/app/components/checkin/checkin.html:309
-#: src/app/components/user/user.html:607
+#: src/app/components/user/user.html:605
 msgid "Add location"
 msgstr ""
 
@@ -132,19 +132,19 @@ msgstr ""
 msgid "Add new user"
 msgstr ""
 
-#: src/app/components/user/user.html:218
+#: src/app/components/user/user.html:216
 msgid "Add phone number:"
 msgstr ""
 
-#: src/app/components/user/user.html:393
+#: src/app/components/user/user.html:391
 msgid "Add social network:"
 msgstr ""
 
-#: src/app/components/user/user.html:754
+#: src/app/components/user/user.html:752
 msgid "Add website:"
 msgstr ""
 
-#: src/app/components/user/user.html:660
+#: src/app/components/user/user.html:658
 msgid "Additional Information"
 msgstr ""
 
@@ -152,8 +152,8 @@ msgstr ""
 msgid "Administrative Officer"
 msgstr ""
 
-#: src/app/components/user/user.html:790
-#: src/app/components/user/user.html:801
+#: src/app/components/user/user.html:788
+#: src/app/components/user/user.html:799
 msgid "Administrator"
 msgstr ""
 
@@ -251,7 +251,7 @@ msgstr ""
 msgid "Authorized Applications"
 msgstr ""
 
-#: src/app/components/user/user.html:817
+#: src/app/components/user/user.html:815
 msgid "Authorized Clients"
 msgstr ""
 
@@ -403,11 +403,11 @@ msgstr ""
 msgid "Cluster Coordinator"
 msgstr ""
 
-#: src/app/components/user/user.html:714
+#: src/app/components/user/user.html:712
 msgid "Clusters / Working Groups"
 msgstr ""
 
-#: src/app/components/user/user.html:738
+#: src/app/components/user/user.html:736
 msgid "Co-ordination Hubs"
 msgstr ""
 
@@ -430,8 +430,8 @@ msgstr ""
 msgid "Confirm new password"
 msgstr ""
 
-#: src/app/components/user/user.html:157
-#: src/app/components/user/user.html:166
+#: src/app/components/user/user.html:155
+#: src/app/components/user/user.html:164
 msgid "Connect"
 msgstr ""
 
@@ -447,7 +447,7 @@ msgstr ""
 msgid "Contact"
 msgstr ""
 
-#: src/app/components/user/user.html:186
+#: src/app/components/user/user.html:184
 msgid "Contact Information"
 msgstr ""
 
@@ -515,7 +515,7 @@ msgstr ""
 msgid "Create your own contact lists and share them with others. Let others check in to your lists or decide for yourself who can join."
 msgstr ""
 
-#: src/app/components/user/user.html:830
+#: src/app/components/user/user.html:828
 msgid "Created"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgid "Disaster"
 msgstr ""
 
 #: src/app/components/operations/operation.html:86
-#: src/app/components/user/user.html:726
+#: src/app/components/user/user.html:724
 msgid "Disasters"
 msgstr ""
 
@@ -707,14 +707,14 @@ msgstr ""
 #: src/app/components/user/kiosk.html:127
 #: src/app/components/user/kiosk.html:27
 #: src/app/components/user/new-user.html:3
-#: src/app/components/user/user.html:288
+#: src/app/components/user/user.html:286
 msgid "Email"
 msgstr ""
 
 #: src/app/components/checkin/checkin.html:230
 #: src/app/components/user/new-user.html:4
-#: src/app/components/user/user.html:325
-#: src/app/components/user/user.html:326
+#: src/app/components/user/user.html:323
+#: src/app/components/user/user.html:324
 msgid "Email address"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "Email addresses must be verified before they can be set as primary."
 msgstr ""
 
-#: src/app/components/user/user.html:318
+#: src/app/components/user/user.html:316
 msgid "Email type"
 msgstr ""
 
@@ -754,7 +754,7 @@ msgstr ""
 msgid "Export options"
 msgstr ""
 
-#: src/app/components/user/user.html:145
+#: src/app/components/user/user.html:143
 msgid "Family name"
 msgstr ""
 
@@ -832,7 +832,7 @@ msgstr ""
 msgid "Forgot/Reset password"
 msgstr ""
 
-#: src/app/components/user/user.html:663
+#: src/app/components/user/user.html:661
 msgid "Functional roles"
 msgstr ""
 
@@ -856,7 +856,7 @@ msgstr ""
 msgid "Ghost"
 msgstr ""
 
-#: src/app/components/user/user.html:142
+#: src/app/components/user/user.html:140
 msgid "Given name"
 msgstr ""
 
@@ -920,7 +920,7 @@ msgstr ""
 msgid "Humanitarian contacts"
 msgstr ""
 
-#: src/app/components/user/user.html:428
+#: src/app/components/user/user.html:426
 msgid "Humanitarian details"
 msgstr ""
 
@@ -947,7 +947,7 @@ msgid "If you want to join a list temporarily, add a check-out date. We’ll sen
 msgstr ""
 
 #: src/app/components/start/start.html:44
-#: src/app/components/user/user.html:466
+#: src/app/components/user/user.html:464
 msgid "If your organization is not listed, click <a href=\"https://docs.google.com/a/humanitarianresponse.info/forms/d/e/1FAIpQLSdpkMue4gFydSm1PwhSIQonpWRGG50ouJJdo8NbcvaMv_pcDw/viewform?c=0&w=1\" target=\"_blank\">here</a> to request adding it."
 msgstr ""
 
@@ -984,7 +984,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: src/app/components/user/user.html:491
+#: src/app/components/user/user.html:489
 msgid "Job titles"
 msgstr ""
 
@@ -1010,7 +1010,7 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: src/app/components/user/user.html:829
+#: src/app/components/user/user.html:827
 msgid "Last Updated"
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr ""
 
 #: src/app/components/checkin/checkin.html:303
 #: src/app/components/start/start.html:81
-#: src/app/components/user/user.html:597
+#: src/app/components/user/user.html:595
 msgid "Locality"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Location filters"
 msgstr ""
 
-#: src/app/components/user/user.html:545
+#: src/app/components/user/user.html:543
 msgid "Locations"
 msgstr ""
 
@@ -1129,8 +1129,8 @@ msgid "Manage your own lists"
 msgstr ""
 
 #: src/app/components/user/UsersController.js:75
-#: src/app/components/user/user.html:791
-#: src/app/components/user/user.html:810
+#: src/app/components/user/user.html:789
+#: src/app/components/user/user.html:808
 msgid "Manager"
 msgstr ""
 
@@ -1227,7 +1227,7 @@ msgstr ""
 msgid "No approved connections"
 msgstr ""
 
-#: src/app/components/user/user.html:823
+#: src/app/components/user/user.html:821
 msgid "No authorized client"
 msgstr ""
 
@@ -1235,7 +1235,7 @@ msgstr ""
 msgid "No email"
 msgstr ""
 
-#: src/app/components/user/user.html:310
+#: src/app/components/user/user.html:308
 msgid "No emails"
 msgstr ""
 
@@ -1243,7 +1243,7 @@ msgstr ""
 msgid "No job title"
 msgstr ""
 
-#: src/app/components/user/user.html:498
+#: src/app/components/user/user.html:496
 msgid "No job titles"
 msgstr ""
 
@@ -1259,7 +1259,7 @@ msgstr ""
 msgid "No location"
 msgstr ""
 
-#: src/app/components/user/user.html:568
+#: src/app/components/user/user.html:566
 msgid "No locations"
 msgstr ""
 
@@ -1271,7 +1271,7 @@ msgstr ""
 msgid "No modifications"
 msgstr ""
 
-#: src/app/components/user/user.html:439
+#: src/app/components/user/user.html:437
 msgid "No organizations"
 msgstr ""
 
@@ -1279,7 +1279,7 @@ msgstr ""
 msgid "No pending connections"
 msgstr ""
 
-#: src/app/components/user/user.html:792
+#: src/app/components/user/user.html:790
 msgid "No permissions set"
 msgstr ""
 
@@ -1287,7 +1287,7 @@ msgstr ""
 msgid "No phone number"
 msgstr ""
 
-#: src/app/components/user/user.html:212
+#: src/app/components/user/user.html:210
 msgid "No phone numbers"
 msgstr ""
 
@@ -1295,11 +1295,11 @@ msgstr ""
 msgid "No results found"
 msgstr ""
 
-#: src/app/components/user/user.html:696
+#: src/app/components/user/user.html:694
 msgid "No roles"
 msgstr ""
 
-#: src/app/components/user/user.html:420
+#: src/app/components/user/user.html:418
 msgid "No social networks"
 msgstr ""
 
@@ -1311,7 +1311,7 @@ msgstr ""
 msgid "No subscriptions"
 msgstr ""
 
-#: src/app/components/user/user.html:775
+#: src/app/components/user/user.html:773
 msgid "No websites"
 msgstr ""
 
@@ -1374,7 +1374,7 @@ msgid "Operation saved successfully"
 msgstr ""
 
 #: src/app/components/operations/operations.html:3
-#: src/app/components/user/user.html:702
+#: src/app/components/user/user.html:700
 msgid "Operations"
 msgstr ""
 
@@ -1399,7 +1399,7 @@ msgstr ""
 msgid "Organization Type"
 msgstr ""
 
-#: src/app/components/user/user.html:432
+#: src/app/components/user/user.html:430
 msgid "Organizations"
 msgstr ""
 
@@ -1452,7 +1452,7 @@ msgstr ""
 msgid "People on the list only"
 msgstr ""
 
-#: src/app/components/user/user.html:788
+#: src/app/components/user/user.html:786
 msgid "Permissions"
 msgstr ""
 
@@ -1460,12 +1460,12 @@ msgstr ""
 msgid "Personal"
 msgstr ""
 
-#: src/app/components/user/user.html:190
+#: src/app/components/user/user.html:188
 msgid "Phone numbers"
 msgstr ""
 
 #: src/app/components/checkin/checkin.html:158
-#: src/app/components/user/user.html:220
+#: src/app/components/user/user.html:218
 msgid "Phone type:"
 msgstr ""
 
@@ -1595,9 +1595,9 @@ msgstr ""
 msgid "Report a Problem"
 msgstr ""
 
-#: src/app/components/user/user.html:194
-#: src/app/components/user/user.html:293
-#: src/app/components/user/user.html:550
+#: src/app/components/user/user.html:192
+#: src/app/components/user/user.html:291
+#: src/app/components/user/user.html:548
 msgid "Request"
 msgstr ""
 
@@ -1737,7 +1737,7 @@ msgid "See all"
 msgstr ""
 
 #: src/app/components/checkin/checkin.html:282
-#: src/app/components/user/user.html:577
+#: src/app/components/user/user.html:575
 msgid "Select a country"
 msgstr ""
 
@@ -1763,16 +1763,16 @@ msgstr ""
 
 #: src/app/components/checkin/checkin.html:293
 #: src/app/components/start/start.html:71
-#: src/app/components/user/user.html:587
+#: src/app/components/user/user.html:585
 msgid "Select a region"
 msgstr ""
 
-#: src/app/components/user/user.html:670
+#: src/app/components/user/user.html:668
 msgid "Select a role"
 msgstr ""
 
 #: src/app/components/trustedDomain/trustedDomains.html:25
-#: src/app/components/user/user.html:450
+#: src/app/components/user/user.html:448
 msgid "Select an organisation"
 msgstr ""
 
@@ -1856,23 +1856,23 @@ msgstr ""
 msgid "Set a date to be automatically checked out:"
 msgstr ""
 
-#: src/app/components/user/user.html:339
+#: src/app/components/user/user.html:337
 msgid "Set primary email:"
 msgstr ""
 
-#: src/app/components/user/user.html:519
+#: src/app/components/user/user.html:517
 msgid "Set primary job title:"
 msgstr ""
 
-#: src/app/components/user/user.html:613
+#: src/app/components/user/user.html:611
 msgid "Set primary location:"
 msgstr ""
 
-#: src/app/components/user/user.html:471
+#: src/app/components/user/user.html:469
 msgid "Set primary organization:"
 msgstr ""
 
-#: src/app/components/user/user.html:242
+#: src/app/components/user/user.html:240
 msgid "Set primary phone number:"
 msgstr ""
 
@@ -1898,7 +1898,7 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: src/app/components/user/user.html:389
+#: src/app/components/user/user.html:387
 msgid "Social Networks"
 msgstr ""
 
@@ -1933,7 +1933,7 @@ msgstr ""
 msgid "Sort by"
 msgstr ""
 
-#: src/app/components/user/user.html:148
+#: src/app/components/user/user.html:146
 msgid "Status"
 msgstr ""
 
@@ -2159,7 +2159,7 @@ msgstr ""
 
 #: src/app/components/checkin/checkin.html:304
 #: src/app/components/start/start.html:82
-#: src/app/components/user/user.html:598
+#: src/app/components/user/user.html:596
 msgid "Type a locality"
 msgstr ""
 
@@ -2262,7 +2262,7 @@ msgstr ""
 msgid "User was successfully notified"
 msgstr ""
 
-#: src/app/components/user/user.html:403
+#: src/app/components/user/user.html:401
 msgid "Username"
 msgstr ""
 
@@ -2280,7 +2280,7 @@ msgstr ""
 msgid "Verified"
 msgstr ""
 
-#: src/app/components/user/user.html:782
+#: src/app/components/user/user.html:780
 msgid "Verified by"
 msgstr ""
 
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "We could not unsubscribe you from this service"
 msgstr ""
 
-#: src/app/components/user/user.html:751
+#: src/app/components/user/user.html:749
 msgid "Websites"
 msgstr ""
 
@@ -2379,15 +2379,15 @@ msgstr ""
 msgid "Who can view this list?"
 msgstr ""
 
-#: src/app/components/user/user.html:367
+#: src/app/components/user/user.html:365
 msgid "Who should be able to see your email addresses?"
 msgstr ""
 
-#: src/app/components/user/user.html:637
+#: src/app/components/user/user.html:635
 msgid "Who should be able to see your locations?"
 msgstr ""
 
-#: src/app/components/user/user.html:265
+#: src/app/components/user/user.html:263
 msgid "Who should be able to see your phone numbers?"
 msgstr ""
 
@@ -2495,9 +2495,9 @@ msgid "Your check in modifications"
 msgstr ""
 
 #: src/app/components/user/UserController.js:41
-#: src/app/components/user/user.html:199
-#: src/app/components/user/user.html:297
-#: src/app/components/user/user.html:555
+#: src/app/components/user/user.html:197
+#: src/app/components/user/user.html:295
+#: src/app/components/user/user.html:553
 msgid "Your connection request is pending"
 msgstr ""
 
@@ -2608,11 +2608,11 @@ msgstr ""
 msgid "contacts found"
 msgstr ""
 
-#: src/app/components/user/user.html:293
+#: src/app/components/user/user.html:291
 msgid "email address"
 msgstr ""
 
-#: src/app/components/user/user.html:301
+#: src/app/components/user/user.html:299
 msgid "email addresses can only be viewed by verified users."
 msgstr ""
 
@@ -2628,11 +2628,11 @@ msgstr ""
 msgid "lists found"
 msgstr ""
 
-#: src/app/components/user/user.html:550
+#: src/app/components/user/user.html:548
 msgid "location"
 msgstr ""
 
-#: src/app/components/user/user.html:559
+#: src/app/components/user/user.html:557
 msgid "locations can only be viewed by verified users."
 msgstr ""
 
@@ -2644,11 +2644,11 @@ msgstr ""
 msgid "or return to the"
 msgstr ""
 
-#: src/app/components/user/user.html:194
+#: src/app/components/user/user.html:192
 msgid "phone number"
 msgstr ""
 
-#: src/app/components/user/user.html:203
+#: src/app/components/user/user.html:201
 msgid "phone numbers can only be viewed by verified users."
 msgstr ""
 
@@ -2657,7 +2657,7 @@ msgid "removed"
 msgstr ""
 
 #: src/app/components/checkin/checkin.html:207
-#: src/app/components/user/user.html:355
+#: src/app/components/user/user.html:353
 msgid "resend validation email"
 msgstr ""
 

--- a/src/po/template.pot
+++ b/src/po/template.pot
@@ -259,10 +259,6 @@ msgstr ""
 msgid "Authorized applications"
 msgstr ""
 
-#: src/app/components/footer/footer.html:12
-msgid "Blog"
-msgstr ""
-
 #: src/app/components/alerts/alertService.js:32
 #: src/app/components/checkin/editCheckinModal.html:34
 #: src/app/components/user/preferences.html:32
@@ -416,7 +412,7 @@ msgstr ""
 msgid "Co-ordination hub"
 msgstr ""
 
-#: src/app/components/footer/footer.html:18
+#: src/app/components/footer/footer.html:12
 #: src/app/components/user/users-export.html:9
 msgid "Code of conduct"
 msgstr ""
@@ -443,7 +439,7 @@ msgstr ""
 msgid "Connection request sent"
 msgstr ""
 
-#: src/app/components/footer/footer.html:24
+#: src/app/components/footer/footer.html:18
 msgid "Contact"
 msgstr ""
 
@@ -619,7 +615,7 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: src/app/components/footer/footer.html:15
+#: src/app/components/footer/footer.html:9
 msgid "Developers"
 msgstr ""
 
@@ -1972,15 +1968,11 @@ msgstr ""
 msgid "Suggested services"
 msgstr ""
 
-#: src/app/components/footer/footer.html:9
-msgid "Support"
-msgstr ""
-
 #: src/app/components/user/users-export.html:42
 msgid "Synchronize with Google Spreadsheet"
 msgstr ""
 
-#: src/app/components/footer/footer.html:21
+#: src/app/components/footer/footer.html:15
 msgid "Terms of Service"
 msgstr ""
 

--- a/src/po/template.pot
+++ b/src/po/template.pot
@@ -1022,10 +1022,6 @@ msgstr ""
 msgid "Last update of your profile"
 msgstr ""
 
-#: src/app/components/landing/landing.html:163
-msgid "Learn how to verify it"
-msgstr ""
-
 #: src/app/components/trustedDomain/trustedDomains.html:44
 msgid "List"
 msgstr ""
@@ -2564,14 +2560,6 @@ msgstr ""
 
 #: src/app/common/messages.html:2
 msgid "Your passwords do not match"
-msgstr ""
-
-#: src/app/components/landing/landing.html:161
-msgid "Your profile has been verified."
-msgstr ""
-
-#: src/app/components/landing/landing.html:162
-msgid "Your profile is not verified."
 msgstr ""
 
 #: src/app/components/list/list.html:97

--- a/src/po/template.pot
+++ b/src/po/template.pot
@@ -75,11 +75,11 @@ msgstr ""
 msgid "Add Service"
 msgstr ""
 
-#: src/app/components/user/user.html:504
+#: src/app/components/user/user.html:503
 msgid "Add a job title"
 msgstr ""
 
-#: src/app/components/user/user.html:502
+#: src/app/components/user/user.html:501
 msgid "Add a job title:"
 msgstr ""
 
@@ -116,7 +116,7 @@ msgid "Add email:"
 msgstr ""
 
 #: src/app/components/checkin/checkin.html:309
-#: src/app/components/user/user.html:605
+#: src/app/components/user/user.html:604
 msgid "Add location"
 msgstr ""
 
@@ -140,11 +140,11 @@ msgstr ""
 msgid "Add social network:"
 msgstr ""
 
-#: src/app/components/user/user.html:752
+#: src/app/components/user/user.html:751
 msgid "Add website:"
 msgstr ""
 
-#: src/app/components/user/user.html:658
+#: src/app/components/user/user.html:657
 msgid "Additional Information"
 msgstr ""
 
@@ -152,8 +152,8 @@ msgstr ""
 msgid "Administrative Officer"
 msgstr ""
 
-#: src/app/components/user/user.html:788
-#: src/app/components/user/user.html:799
+#: src/app/components/user/user.html:787
+#: src/app/components/user/user.html:798
 msgid "Administrator"
 msgstr ""
 
@@ -251,7 +251,7 @@ msgstr ""
 msgid "Authorized Applications"
 msgstr ""
 
-#: src/app/components/user/user.html:815
+#: src/app/components/user/user.html:814
 msgid "Authorized Clients"
 msgstr ""
 
@@ -403,11 +403,11 @@ msgstr ""
 msgid "Cluster Coordinator"
 msgstr ""
 
-#: src/app/components/user/user.html:712
+#: src/app/components/user/user.html:711
 msgid "Clusters / Working Groups"
 msgstr ""
 
-#: src/app/components/user/user.html:736
+#: src/app/components/user/user.html:735
 msgid "Co-ordination Hubs"
 msgstr ""
 
@@ -515,7 +515,7 @@ msgstr ""
 msgid "Create your own contact lists and share them with others. Let others check in to your lists or decide for yourself who can join."
 msgstr ""
 
-#: src/app/components/user/user.html:828
+#: src/app/components/user/user.html:827
 msgid "Created"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgid "Disaster"
 msgstr ""
 
 #: src/app/components/operations/operation.html:86
-#: src/app/components/user/user.html:724
+#: src/app/components/user/user.html:723
 msgid "Disasters"
 msgstr ""
 
@@ -832,7 +832,7 @@ msgstr ""
 msgid "Forgot/Reset password"
 msgstr ""
 
-#: src/app/components/user/user.html:661
+#: src/app/components/user/user.html:660
 msgid "Functional roles"
 msgstr ""
 
@@ -946,11 +946,6 @@ msgstr ""
 msgid "If you want to join a list temporarily, add a check-out date. We’ll send you a reminder shortly before the given date and we’ll check you out automatically at the date you specified."
 msgstr ""
 
-#: src/app/components/start/start.html:44
-#: src/app/components/user/user.html:464
-msgid "If your organization is not listed, click <a href=\"https://docs.google.com/a/humanitarianresponse.info/forms/d/e/1FAIpQLSdpkMue4gFydSm1PwhSIQonpWRGG50ouJJdo8NbcvaMv_pcDw/viewform?c=0&w=1\" target=\"_blank\">here</a> to request adding it."
-msgstr ""
-
 #: src/app/components/user/UserController.js:180
 msgid "In order to view this person’s profile, please contact info@humanitarian.id"
 msgstr ""
@@ -984,7 +979,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: src/app/components/user/user.html:489
+#: src/app/components/user/user.html:488
 msgid "Job titles"
 msgstr ""
 
@@ -1010,7 +1005,7 @@ msgstr ""
 msgid "Last Name"
 msgstr ""
 
-#: src/app/components/user/user.html:827
+#: src/app/components/user/user.html:826
 msgid "Last Updated"
 msgstr ""
 
@@ -1064,8 +1059,8 @@ msgid "Locale"
 msgstr ""
 
 #: src/app/components/checkin/checkin.html:303
-#: src/app/components/start/start.html:81
-#: src/app/components/user/user.html:595
+#: src/app/components/start/start.html:80
+#: src/app/components/user/user.html:594
 msgid "Locality"
 msgstr ""
 
@@ -1073,7 +1068,7 @@ msgstr ""
 msgid "Location filters"
 msgstr ""
 
-#: src/app/components/user/user.html:543
+#: src/app/components/user/user.html:542
 msgid "Locations"
 msgstr ""
 
@@ -1125,8 +1120,8 @@ msgid "Manage your own lists"
 msgstr ""
 
 #: src/app/components/user/UsersController.js:75
-#: src/app/components/user/user.html:789
-#: src/app/components/user/user.html:808
+#: src/app/components/user/user.html:788
+#: src/app/components/user/user.html:807
 msgid "Manager"
 msgstr ""
 
@@ -1206,9 +1201,9 @@ msgid "New password"
 msgstr ""
 
 #: src/app/components/start/start.html:24
-#: src/app/components/start/start.html:48
-#: src/app/components/start/start.html:86
-#: src/app/components/start/start.html:98
+#: src/app/components/start/start.html:47
+#: src/app/components/start/start.html:85
+#: src/app/components/start/start.html:97
 #: src/app/components/start/tutorial.html:87
 #: src/app/components/user/kiosk.html:22
 #: src/app/components/user/kiosk.html:34
@@ -1223,7 +1218,7 @@ msgstr ""
 msgid "No approved connections"
 msgstr ""
 
-#: src/app/components/user/user.html:821
+#: src/app/components/user/user.html:820
 msgid "No authorized client"
 msgstr ""
 
@@ -1239,7 +1234,7 @@ msgstr ""
 msgid "No job title"
 msgstr ""
 
-#: src/app/components/user/user.html:496
+#: src/app/components/user/user.html:495
 msgid "No job titles"
 msgstr ""
 
@@ -1255,7 +1250,7 @@ msgstr ""
 msgid "No location"
 msgstr ""
 
-#: src/app/components/user/user.html:566
+#: src/app/components/user/user.html:565
 msgid "No locations"
 msgstr ""
 
@@ -1275,7 +1270,7 @@ msgstr ""
 msgid "No pending connections"
 msgstr ""
 
-#: src/app/components/user/user.html:790
+#: src/app/components/user/user.html:789
 msgid "No permissions set"
 msgstr ""
 
@@ -1291,7 +1286,7 @@ msgstr ""
 msgid "No results found"
 msgstr ""
 
-#: src/app/components/user/user.html:694
+#: src/app/components/user/user.html:693
 msgid "No roles"
 msgstr ""
 
@@ -1307,7 +1302,7 @@ msgstr ""
 msgid "No subscriptions"
 msgstr ""
 
-#: src/app/components/user/user.html:773
+#: src/app/components/user/user.html:772
 msgid "No websites"
 msgstr ""
 
@@ -1370,7 +1365,7 @@ msgid "Operation saved successfully"
 msgstr ""
 
 #: src/app/components/operations/operations.html:3
-#: src/app/components/user/user.html:700
+#: src/app/components/user/user.html:699
 msgid "Operations"
 msgstr ""
 
@@ -1448,7 +1443,7 @@ msgstr ""
 msgid "People on the list only"
 msgstr ""
 
-#: src/app/components/user/user.html:786
+#: src/app/components/user/user.html:785
 msgid "Permissions"
 msgstr ""
 
@@ -1593,7 +1588,7 @@ msgstr ""
 
 #: src/app/components/user/user.html:192
 #: src/app/components/user/user.html:291
-#: src/app/components/user/user.html:548
+#: src/app/components/user/user.html:547
 msgid "Request"
 msgstr ""
 
@@ -1658,7 +1653,7 @@ msgstr ""
 msgid "Search by name"
 msgstr ""
 
-#: src/app/components/start/start.html:60
+#: src/app/components/start/start.html:59
 msgid "Search for a country"
 msgstr ""
 
@@ -1733,7 +1728,7 @@ msgid "See all"
 msgstr ""
 
 #: src/app/components/checkin/checkin.html:282
-#: src/app/components/user/user.html:575
+#: src/app/components/user/user.html:574
 msgid "Select a country"
 msgstr ""
 
@@ -1758,12 +1753,12 @@ msgid "Select a primary phone number:"
 msgstr ""
 
 #: src/app/components/checkin/checkin.html:293
-#: src/app/components/start/start.html:71
-#: src/app/components/user/user.html:585
+#: src/app/components/start/start.html:70
+#: src/app/components/user/user.html:584
 msgid "Select a region"
 msgstr ""
 
-#: src/app/components/user/user.html:668
+#: src/app/components/user/user.html:667
 msgid "Select a role"
 msgstr ""
 
@@ -1856,15 +1851,15 @@ msgstr ""
 msgid "Set primary email:"
 msgstr ""
 
-#: src/app/components/user/user.html:517
+#: src/app/components/user/user.html:516
 msgid "Set primary job title:"
 msgstr ""
 
-#: src/app/components/user/user.html:611
+#: src/app/components/user/user.html:610
 msgid "Set primary location:"
 msgstr ""
 
-#: src/app/components/user/user.html:469
+#: src/app/components/user/user.html:468
 msgid "Set primary organization:"
 msgstr ""
 
@@ -2154,8 +2149,8 @@ msgid "Type"
 msgstr ""
 
 #: src/app/components/checkin/checkin.html:304
-#: src/app/components/start/start.html:82
-#: src/app/components/user/user.html:596
+#: src/app/components/start/start.html:81
+#: src/app/components/user/user.html:595
 msgid "Type a locality"
 msgstr ""
 
@@ -2276,7 +2271,7 @@ msgstr ""
 msgid "Verified"
 msgstr ""
 
-#: src/app/components/user/user.html:780
+#: src/app/components/user/user.html:779
 msgid "Verified by"
 msgstr ""
 
@@ -2342,7 +2337,7 @@ msgstr ""
 msgid "We could not unsubscribe you from this service"
 msgstr ""
 
-#: src/app/components/user/user.html:749
+#: src/app/components/user/user.html:748
 msgid "Websites"
 msgstr ""
 
@@ -2355,7 +2350,7 @@ msgstr ""
 msgid "What are these?"
 msgstr ""
 
-#: src/app/components/start/start.html:58
+#: src/app/components/start/start.html:57
 msgid "What is your primary location?"
 msgstr ""
 
@@ -2379,7 +2374,7 @@ msgstr ""
 msgid "Who should be able to see your email addresses?"
 msgstr ""
 
-#: src/app/components/user/user.html:635
+#: src/app/components/user/user.html:634
 msgid "Who should be able to see your locations?"
 msgstr ""
 
@@ -2399,7 +2394,7 @@ msgstr ""
 msgid "You are not part of any lists"
 msgstr ""
 
-#: src/app/components/start/start.html:97
+#: src/app/components/start/start.html:96
 msgid "You can add more information to your profile at any time via the 'Profile' link in your account menu on the top right"
 msgstr ""
 
@@ -2493,7 +2488,7 @@ msgstr ""
 #: src/app/components/user/UserController.js:41
 #: src/app/components/user/user.html:197
 #: src/app/components/user/user.html:295
-#: src/app/components/user/user.html:553
+#: src/app/components/user/user.html:552
 msgid "Your connection request is pending"
 msgstr ""
 
@@ -2616,11 +2611,11 @@ msgstr ""
 msgid "lists found"
 msgstr ""
 
-#: src/app/components/user/user.html:548
+#: src/app/components/user/user.html:547
 msgid "location"
 msgstr ""
 
-#: src/app/components/user/user.html:557
+#: src/app/components/user/user.html:556
 msgid "locations can only be viewed by verified users."
 msgstr ""
 

--- a/src/po/template.pot
+++ b/src/po/template.pot
@@ -234,7 +234,7 @@ msgstr ""
 msgid "Area Coordinator"
 msgstr ""
 
-#: src/app/components/landing/landing.html:145
+#: src/app/components/landing/landing.html:151
 #: src/app/components/notifications/notifications.html:11
 msgid "As of January 2021 the Humanitarian ID contact management features will be decommissioned. More information about this update is available in HID FAQs section."
 msgstr ""
@@ -942,6 +942,10 @@ msgstr ""
 msgid "If you want to join a list temporarily, add a check-out date. We’ll send you a reminder shortly before the given date and we’ll check you out automatically at the date you specified."
 msgstr ""
 
+#: src/app/components/landing/landing.html:3
+msgid "In January 2021, the Humanitarian ID website and app will be decommissioned. Your HID account will remain valid as part of the stand-alone HID Authentication service which can be used to login to any of the partner platforms. More information about this decommissioning is available in the <a href=\"https://about.humanitarian.id/faqs#contacts-decommissioning\">FAQs section</a>."
+msgstr ""
+
 #: src/app/components/user/UserController.js:180
 msgid "In order to view this person’s profile, please contact info@humanitarian.id"
 msgstr ""
@@ -1009,7 +1013,7 @@ msgstr ""
 msgid "Last name"
 msgstr ""
 
-#: src/app/components/landing/landing.html:157
+#: src/app/components/landing/landing.html:163
 msgid "Last update of your profile"
 msgstr ""
 
@@ -1322,7 +1326,7 @@ msgid ""
 "      with HID Authentication service. More info available on the <a href=\"https://about.humanitarian.id/faqs#contacts-decommissioning\" target=\"_blank\" rel=\"noopener\">FAQs page</a>."
 msgstr ""
 
-#: src/app/components/landing/landing.html:136
+#: src/app/components/landing/landing.html:142
 #: src/app/components/notifications/notifications.html:5
 msgid "Notifications"
 msgstr ""
@@ -1533,9 +1537,9 @@ msgstr ""
 msgid "Read more"
 msgstr ""
 
-#: src/app/components/landing/landing.html:121
-#: src/app/components/landing/landing.html:43
-#: src/app/components/landing/landing.html:82
+#: src/app/components/landing/landing.html:127
+#: src/app/components/landing/landing.html:49
+#: src/app/components/landing/landing.html:88
 msgid "Recent:&nbsp;"
 msgstr ""
 
@@ -1664,8 +1668,8 @@ msgstr ""
 msgid "Search for a country"
 msgstr ""
 
-#: src/app/components/landing/landing.html:64
-#: src/app/components/landing/landing.html:65
+#: src/app/components/landing/landing.html:70
+#: src/app/components/landing/landing.html:71
 msgid "Search for a country / region"
 msgstr ""
 
@@ -1675,13 +1679,13 @@ msgstr ""
 msgid "Search for a list"
 msgstr ""
 
-#: src/app/components/landing/landing.html:102
-#: src/app/components/landing/landing.html:103
+#: src/app/components/landing/landing.html:108
+#: src/app/components/landing/landing.html:109
 msgid "Search for a list name"
 msgstr ""
 
-#: src/app/components/landing/landing.html:24
-#: src/app/components/landing/landing.html:25
+#: src/app/components/landing/landing.html:30
+#: src/app/components/landing/landing.html:31
 #: src/app/components/user/user.html:82
 #: src/app/components/user/user.html:83
 msgid "Search for a name"
@@ -1695,7 +1699,7 @@ msgstr ""
 msgid "Search for an organisation"
 msgstr ""
 
-#: src/app/components/landing/landing.html:19
+#: src/app/components/landing/landing.html:25
 msgid "Search for contacts"
 msgstr ""
 
@@ -1707,11 +1711,11 @@ msgstr ""
 msgid "Search for contacts or lists"
 msgstr ""
 
-#: src/app/components/landing/landing.html:61
+#: src/app/components/landing/landing.html:67
 msgid "Search for operation lists"
 msgstr ""
 
-#: src/app/components/landing/landing.html:99
+#: src/app/components/landing/landing.html:105
 msgid "Search for other contact lists"
 msgstr ""
 
@@ -2298,10 +2302,10 @@ msgstr ""
 msgid "View Trusted Domains"
 msgstr ""
 
-#: src/app/components/landing/landing.html:116
-#: src/app/components/landing/landing.html:138
-#: src/app/components/landing/landing.html:38
-#: src/app/components/landing/landing.html:78
+#: src/app/components/landing/landing.html:122
+#: src/app/components/landing/landing.html:144
+#: src/app/components/landing/landing.html:44
+#: src/app/components/landing/landing.html:84
 #: src/app/components/user/user.html:96
 msgid "View all"
 msgstr ""
@@ -2334,7 +2338,7 @@ msgstr ""
 msgid "Websites"
 msgstr ""
 
-#: src/app/components/landing/landing.html:4
+#: src/app/components/landing/landing.html:10
 msgid "Welcome to Humanitarian ID"
 msgstr ""
 

--- a/src/po/template.pot
+++ b/src/po/template.pot
@@ -1318,6 +1318,14 @@ msgstr ""
 msgid "Note: Allow some time for the email to get to your inbox (especially if using @un.org domain). If you do not receive it, get in touch with us at <a href=\"mailto:info@humanitarian.id\">info@humanitarian.id</a>"
 msgstr ""
 
+#: src/app/components/auth/register.html:6
+msgid ""
+"Note: As of January 2021 the Humanitarian ID contact management features\n"
+"      on this platform will be decommissioned. However, your account will remain\n"
+"      valid to access all <a href=\"https://about.humanitarian.id/partners-using-our-authentication-service\" target=\"_blank\" rel=\"noopener\">websites integrated</a>\n"
+"      with HID Authentication service. More info available on the <a href=\"https://about.humanitarian.id/faqs#contacts-decommissioning\" target=\"_blank\" rel=\"noopener\">FAQs page</a>."
+msgstr ""
+
 #: src/app/components/landing/landing.html:136
 #: src/app/components/notifications/notifications.html:5
 msgid "Notifications"
@@ -1552,10 +1560,13 @@ msgstr ""
 msgid "Region"
 msgstr ""
 
-#: src/app/components/auth/register.html:4
 #: src/app/components/user/kiosk.html:131
 #: src/app/components/user/new-user.html:41
 msgid "Register"
+msgstr ""
+
+#: src/app/components/auth/register.html:4
+msgid "Register a Humanitarian ID account"
 msgstr ""
 
 #: src/app/components/auth/login.html:22
@@ -1877,12 +1888,6 @@ msgstr ""
 
 #: src/app/components/search/search-results.html:42
 msgid "Showing lists"
-msgstr ""
-
-#: src/app/components/auth/register.html:6
-msgid ""
-"Sign up for a Humanitarian ID account. Doing so will give you access to Humanitarian ID as well as a growing number of\n"
-"\t\t\t<a href=\"https://about.humanitarian.id/partners-using-our-authentication-service\" target=\"_blank\">related humanitarian community sites</a>."
 msgstr ""
 
 #: src/app/components/service/suggestions.html:27

--- a/src/po/template.pot
+++ b/src/po/template.pot
@@ -299,7 +299,7 @@ msgid "Changed primary phone number to:"
 msgstr ""
 
 #: src/app/components/checkin/checkin.html:409
-#: src/app/components/header/header.html:126
+#: src/app/components/header/header.html:125
 msgid "Check in"
 msgstr ""
 
@@ -325,7 +325,7 @@ msgid "Check me in"
 msgstr ""
 
 #: src/app/components/checkin/checkout-page.html:4
-#: src/app/components/header/header.html:127
+#: src/app/components/header/header.html:126
 msgid "Check out"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgid "Current phone number"
 msgstr ""
 
 #: src/app/components/dashboard/dashboard.html:4
-#: src/app/components/header/header.html:124
+#: src/app/components/header/header.html:123
 msgid "Dashboard"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Family name"
 msgstr ""
 
-#: src/app/components/header/header.html:90
+#: src/app/components/header/header.html:89
 msgid "Feedback"
 msgstr ""
 
@@ -915,7 +915,7 @@ msgstr ""
 msgid "Humanitarian ID is also available as a mobile app for iOS and Android."
 msgstr ""
 
-#: src/app/components/header/header.html:125
+#: src/app/components/header/header.html:124
 #: src/app/components/search/SearchController.js:13
 msgid "Humanitarian contacts"
 msgstr ""
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Log in to Humanitarian ID."
 msgstr ""
 
-#: src/app/components/header/header.html:91
+#: src/app/components/header/header.html:90
 msgid "Log out"
 msgstr ""
 
@@ -2132,10 +2132,6 @@ msgstr ""
 
 #: src/app/components/user/preferences.html:261
 msgid "Trusted devices"
-msgstr ""
-
-#: src/app/components/header/header.html:89
-msgid "Tutorial"
 msgstr ""
 
 #: src/app/components/user/preferences.html:154

--- a/yarn.lock
+++ b/yarn.lock
@@ -4957,9 +4957,9 @@ websocket-driver@>=0.5.1:
     websocket-extensions ">=0.1.1"
 
 websocket-extensions@>=0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
-  integrity sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
+  integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
 
 whatwg-fetch@>=0.10.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -391,9 +391,9 @@ angular-ui-bootstrap@^0.14.1:
   integrity sha1-2WzmBMhLvXBro0qryh1ac3bhi6Y=
 
 angular@>=1.2.0, angular@^1.4.7, angular@^1.5.5, angular@~1.x:
-  version "1.7.9"
-  resolved "https://registry.yarnpkg.com/angular/-/angular-1.7.9.tgz#e52616e8701c17724c3c238cfe4f9446fd570bc4"
-  integrity sha512-5se7ZpcOtu0MBFlzGv5dsM1quQDoDeUTwZrWjGtTNA7O88cD8TEk5IEKCTDa3uECV9XnvKREVUr7du1ACiWGFQ==
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/angular/-/angular-1.8.0.tgz#b1ec179887869215cab6dfd0df2e42caa65b1b51"
+  integrity sha512-VdaMx+Qk0Skla7B5gw77a8hzlcOakwF8mjlW13DpIWIDlfqwAbSSLfd8N/qZnzEmQF4jC4iofInd3gE7vL8ZZg==
 
 ansi-escapes@^4.2.1:
   version "4.3.1"


### PR DESCRIPTION
- HID-2057: include CSS to style errors (for API CSS artifact)
- HID-2084: de-emphasize unverified/verified copy on the website
- HID-2085: remove prompt to verify from website
- HID-2086: remove CTA to add orgs to HID
- HID-2087: copy updates on registration page
- HID-2089: remove elements from Common Design footer
- HID-2090: remove tutorial from user menu
- HID-2096: show message to users loading HID in native app wrapper
