### PR TITLE
HID-2130: restore registration link but point to Auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid_app2",
-  "version": "2.2.12",
+  "version": "2.2.13",
   "description": "HID Client application",
   "main": "index.js",
   "scripts": {

--- a/src/app/components/auth/login.html
+++ b/src/app/components/auth/login.html
@@ -25,6 +25,7 @@
           <span ng-if="!saving" translate>Login</span>
         </button>
       </div>
+      <p><a href="https://auth.humanitarian.id/register">Register a new Humanitarian ID Account</a></p>
       <p><a href="/password_reset" translate>Forgot/Reset password</a></p>
     </form>
   </div>

--- a/src/po/template.pot
+++ b/src/po/template.pot
@@ -799,7 +799,7 @@ msgstr ""
 msgid "Flag suspicious user"
 msgstr ""
 
-#: src/app/components/auth/login.html:28
+#: src/app/components/auth/login.html:29
 msgid "Forgot/Reset password"
 msgstr ""
 


### PR DESCRIPTION
# HID-2130

Restoring the registration link because it was causing confusion that the link was totally missing. Instead we are now pointing to HID Auth registration page. 